### PR TITLE
Fix error handling of asynchronous writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - [0.1.0](#010)
 
 
+## Next Release
+
+- [#27](https://github.com/groue/GRDBCombine/pull/27) by [@groue](http://github.com/groue): Fix error handling of asynchronous writes
+
 ## 0.7.0
 
 Released October 27, 2019

--- a/Sources/GRDBCombine/DatabaseWriiter+Combine.swift
+++ b/Sources/GRDBCombine/DatabaseWriiter+Combine.swift
@@ -43,7 +43,7 @@ extension DatabaseWriter {
         where S : Scheduler
     {
         flatMapWritePublisher(receiveOn: scheduler) { db in
-            Result(catching: { try updates(db) }).publisher
+            try Just(updates(db)).setFailureType(to: Error.self)
         }
     }
     
@@ -88,11 +88,7 @@ extension DatabaseWriter {
         where S : Scheduler
     {
         flatMapWritePublisher(receiveOn: scheduler) { db -> AnyPublisher<Output, Error> in
-            do {
-                return try self.concurrentReadPublisher(input: updates(db), value: value)
-            } catch {
-                return Fail(error: error).eraseToAnyPublisher()
-            }
+            try self.concurrentReadPublisher(input: updates(db), value: value)
         }
     }
     


### PR DESCRIPTION
This pull request fixes a bug in the error handling of asynchronous writes.

They did not rollback the asynchronous transaction in case of error 😓 