### PR TITLE
Fix for Issue #32 - package dependency graph error unresolveable

### DIFF
--- a/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.pbxproj
+++ b/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.pbxproj
@@ -559,8 +559,9 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/CombineExpectations.git";
 			requirement = {
-				kind = exactVersion;
-				version = 0.2.0;
+				kind = versionRange;
+				maximumVersion = 0.4.0;
+				minimumVersion = 0.3.0;
 			};
 		};
 		56B28CF922BA0D8900E65640 /* XCRemoteSwiftPackageReference "GRDB" */ = {

--- a/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.pbxproj
+++ b/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.pbxproj
@@ -559,8 +559,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/CombineExpectations.git";
 			requirement = {
-				kind = versionRange;
-				maximumVersion = 0.4.0;
+				kind = upToNextMajorVersion;
 				minimumVersion = 0.3.0;
 			};
 		};

--- a/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/groue/CombineExpectations.git",
         "state": {
           "branch": null,
-          "revision": "7c13731330c370a6bc7060d8b06667faae20d605",
-          "version": "0.2.0"
+          "revision": "40d564be8decfc9a3e8acfec56a42dd845e5c420",
+          "version": "0.3.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/groue/GRDB.swift",
         "state": {
           "branch": null,
-          "revision": "a67070dd9a08dad455e9f2895a0c40921d31fa1c",
-          "version": "4.6.2"
+          "revision": "4c8574aa4c08ff715ce0e63b38502ac1e8529069",
+          "version": "4.10.0"
         }
       }
     ]

--- a/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Documentation/Demo/GRDBCombineDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/groue/CombineExpectations.git",
         "state": {
           "branch": null,
-          "revision": "40d564be8decfc9a3e8acfec56a42dd845e5c420",
-          "version": "0.3.0"
+          "revision": "3250715d3f1b12754c84e7952c7bbb716f4a4dc4",
+          "version": "0.4.0"
         }
       },
       {

--- a/Documentation/Demo/GRDBCombineDemo/Models/Players.swift
+++ b/Documentation/Demo/GRDBCombineDemo/Models/Players.swift
@@ -56,7 +56,7 @@ struct Players {
     
     // MARK: - Access Players
     
-    /// A Hole of Fame
+    /// A Hall of Fame
     struct HallOfFame {
         /// Total number of players
         var playerCount: Int

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMajor(from: "4.1.0")),
-        .package(url: "https://github.com/groue/CombineExpectations.git", from: "0.3.0")
+        .package(url: "https://github.com/groue/CombineExpectations.git", .upToNextMajor(from: "0.3.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
This fixes "The package dependency graph can not be resolved" error by changing the dependency for GRDB to something more modern and one that is not incompatible with GRDBCombine.

Tested with Xcode 11.3.0 and Xcode 11.4beta2