### PR TITLE
Add DatabaseRequest and DatabaseEditable types + SwiftUI Demo

### DIFF
--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.pbxproj
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.pbxproj
@@ -1,0 +1,421 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B81D58F02439963200A834B5 /* PlayerEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81D58EF2439963200A834B5 /* PlayerEditingView.swift */; };
+		B83CB4E124398D410089966D /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = B83CB4E024398D410089966D /* GRDB */; };
+		B85C801D2439A2E90096491C /* Players.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85C801B2439A2E90096491C /* Players.swift */; };
+		B85C801E2439A2E90096491C /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85C801C2439A2E90096491C /* Player.swift */; };
+		B8AD23A724397E990043DCA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AD23A624397E990043DCA4 /* AppDelegate.swift */; };
+		B8AD23A924397E990043DCA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AD23A824397E990043DCA4 /* SceneDelegate.swift */; };
+		B8AD23AB24397E990043DCA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AD23AA24397E990043DCA4 /* ContentView.swift */; };
+		B8AD23AD24397E9B0043DCA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B8AD23AC24397E9B0043DCA4 /* Assets.xcassets */; };
+		B8AD23B024397E9B0043DCA4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B8AD23AF24397E9B0043DCA4 /* Preview Assets.xcassets */; };
+		B8AD23B324397E9B0043DCA4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B8AD23B124397E9B0043DCA4 /* LaunchScreen.storyboard */; };
+		B8AD23BE24397EC60043DCA4 /* AppDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AD23BB24397EC60043DCA4 /* AppDatabase.swift */; };
+		B8EA0AE52439906A00F2CB74 /* GRDBCombine in Frameworks */ = {isa = PBXBuildFile; productRef = B8EA0AE42439906A00F2CB74 /* GRDBCombine */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B81D58EF2439963200A834B5 /* PlayerEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerEditingView.swift; sourceTree = "<group>"; };
+		B85C801B2439A2E90096491C /* Players.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Players.swift; sourceTree = "<group>"; };
+		B85C801C2439A2E90096491C /* Player.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
+		B85C801F2439A2FF0096491C /* GRDBCombine */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GRDBCombine; path = ../..; sourceTree = "<group>"; };
+		B8AD23A324397E990043DCA4 /* GRDBDemo-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "GRDBDemo-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8AD23A624397E990043DCA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B8AD23A824397E990043DCA4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		B8AD23AA24397E990043DCA4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B8AD23AC24397E9B0043DCA4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B8AD23AF24397E9B0043DCA4 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		B8AD23B224397E9B0043DCA4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		B8AD23B424397E9B0043DCA4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B8AD23BB24397EC60043DCA4 /* AppDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDatabase.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B8AD23A024397E990043DCA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B83CB4E124398D410089966D /* GRDB in Frameworks */,
+				B8EA0AE52439906A00F2CB74 /* GRDBCombine in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B85C801A2439A2E90096491C /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B85C801B2439A2E90096491C /* Players.swift */,
+				B85C801C2439A2E90096491C /* Player.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		B8AD239A24397E980043DCA4 = {
+			isa = PBXGroup;
+			children = (
+				B8AD23A524397E990043DCA4 /* GRDBDemo-SwiftUI */,
+				B8AD23A424397E990043DCA4 /* Products */,
+				B8AE6E18243980D80022FACD /* Frameworks */,
+				B85C801F2439A2FF0096491C /* GRDBCombine */,
+			);
+			sourceTree = "<group>";
+		};
+		B8AD23A424397E990043DCA4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B8AD23A324397E990043DCA4 /* GRDBDemo-SwiftUI.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B8AD23A524397E990043DCA4 /* GRDBDemo-SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				B8AD23A624397E990043DCA4 /* AppDelegate.swift */,
+				B8AD23A824397E990043DCA4 /* SceneDelegate.swift */,
+				B8AD23AA24397E990043DCA4 /* ContentView.swift */,
+				B81D58EF2439963200A834B5 /* PlayerEditingView.swift */,
+				B8AD23BB24397EC60043DCA4 /* AppDatabase.swift */,
+				B85C801A2439A2E90096491C /* Models */,
+				B8AD23C124397EDA0043DCA4 /* Resources */,
+				B8AD23AE24397E9B0043DCA4 /* Preview Content */,
+				B8AD23B424397E9B0043DCA4 /* Info.plist */,
+			);
+			path = "GRDBDemo-SwiftUI";
+			sourceTree = "<group>";
+		};
+		B8AD23AE24397E9B0043DCA4 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				B8AD23AF24397E9B0043DCA4 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		B8AD23C124397EDA0043DCA4 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B8AD23AC24397E9B0043DCA4 /* Assets.xcassets */,
+				B8AD23B124397E9B0043DCA4 /* LaunchScreen.storyboard */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		B8AE6E18243980D80022FACD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B8AD23A224397E990043DCA4 /* GRDBDemo-SwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B8AD23B724397E9B0043DCA4 /* Build configuration list for PBXNativeTarget "GRDBDemo-SwiftUI" */;
+			buildPhases = (
+				B8AD239F24397E990043DCA4 /* Sources */,
+				B8AD23A024397E990043DCA4 /* Frameworks */,
+				B8AD23A124397E990043DCA4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "GRDBDemo-SwiftUI";
+			packageProductDependencies = (
+				B83CB4E024398D410089966D /* GRDB */,
+				B8EA0AE42439906A00F2CB74 /* GRDBCombine */,
+			);
+			productName = "GRDBDemo-SwiftUI";
+			productReference = B8AD23A324397E990043DCA4 /* GRDBDemo-SwiftUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B8AD239B24397E980043DCA4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1140;
+				LastUpgradeCheck = 1140;
+				ORGANIZATIONNAME = "Github-ApptekStudios";
+				TargetAttributes = {
+					B8AD23A224397E990043DCA4 = {
+						CreatedOnToolsVersion = 11.4;
+					};
+				};
+			};
+			buildConfigurationList = B8AD239E24397E980043DCA4 /* Build configuration list for PBXProject "GRDBDemo-SwiftUI" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B8AD239A24397E980043DCA4;
+			packageReferences = (
+				B83CB4DF24398D410089966D /* XCRemoteSwiftPackageReference "GRDB" */,
+			);
+			productRefGroup = B8AD23A424397E990043DCA4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B8AD23A224397E990043DCA4 /* GRDBDemo-SwiftUI */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B8AD23A124397E990043DCA4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B8AD23B324397E9B0043DCA4 /* LaunchScreen.storyboard in Resources */,
+				B8AD23B024397E9B0043DCA4 /* Preview Assets.xcassets in Resources */,
+				B8AD23AD24397E9B0043DCA4 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B8AD239F24397E990043DCA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B85C801D2439A2E90096491C /* Players.swift in Sources */,
+				B8AD23A724397E990043DCA4 /* AppDelegate.swift in Sources */,
+				B81D58F02439963200A834B5 /* PlayerEditingView.swift in Sources */,
+				B8AD23A924397E990043DCA4 /* SceneDelegate.swift in Sources */,
+				B85C801E2439A2E90096491C /* Player.swift in Sources */,
+				B8AD23BE24397EC60043DCA4 /* AppDatabase.swift in Sources */,
+				B8AD23AB24397E990043DCA4 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		B8AD23B124397E9B0043DCA4 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B8AD23B224397E9B0043DCA4 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		B8AD23B524397E9B0043DCA4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B8AD23B624397E9B0043DCA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B8AD23B824397E9B0043DCA4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"GRDBDemo-SwiftUI/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "GRDBDemo-SwiftUI/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.apptekstudios.GRDBDemo-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B8AD23B924397E9B0043DCA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"GRDBDemo-SwiftUI/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "GRDBDemo-SwiftUI/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.apptekstudios.GRDBDemo-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B8AD239E24397E980043DCA4 /* Build configuration list for PBXProject "GRDBDemo-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B8AD23B524397E9B0043DCA4 /* Debug */,
+				B8AD23B624397E9B0043DCA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B8AD23B724397E9B0043DCA4 /* Build configuration list for PBXNativeTarget "GRDBDemo-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B8AD23B824397E9B0043DCA4 /* Debug */,
+				B8AD23B924397E9B0043DCA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B83CB4DF24398D410089966D /* XCRemoteSwiftPackageReference "GRDB" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/groue/GRDB.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.12.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B83CB4E024398D410089966D /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B83CB4DF24398D410089966D /* XCRemoteSwiftPackageReference "GRDB" */;
+			productName = GRDB;
+		};
+		B8EA0AE42439906A00F2CB74 /* GRDBCombine */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GRDBCombine;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = B8AD239B24397E980043DCA4 /* Project object */;
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CombineExpectations",
+        "repositoryURL": "https://github.com/groue/CombineExpectations.git",
+        "state": {
+          "branch": null,
+          "revision": "3250715d3f1b12754c84e7952c7bbb716f4a4dc4",
+          "version": "0.4.0"
+        }
+      },
+      {
+        "package": "GRDB",
+        "repositoryURL": "https://github.com/groue/GRDB.swift",
+        "state": {
+          "branch": null,
+          "revision": "f4c763dc3122ce9695f2cb6d7c163b379ecd4129",
+          "version": "4.12.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/AppDatabase.swift
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/AppDatabase.swift
@@ -1,0 +1,67 @@
+import Foundation
+import GRDB
+
+struct AppDatabase {
+	static var shared = AppDatabase.loadSharedDatabase()
+	
+	static func loadSharedDatabase() -> AppDatabase {
+		do {
+			let databaseURL = try FileManager.default
+				.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+				.appendingPathComponent("db.sqlite")
+			
+			return try self.init(withDatabasePath: databaseURL.path)
+		}
+		catch {
+			fatalError("Couldn't load main application database")
+		}
+	}
+	
+	
+	let db: DatabasePool
+	
+	init(withDatabasePath path: String) throws {
+        // Connect to the database
+        // See https://github.com/groue/GRDB.swift/blob/master/README.md#database-connections
+        self.db = try DatabasePool(path: path)
+        
+        // Define the database schema
+		try migrator.migrate(self.db)
+    }
+    
+    /// The DatabaseMigrator that defines the database schema.
+    ///
+    /// See https://github.com/groue/GRDB.swift/blob/master/README.md#migrations
+    var migrator: DatabaseMigrator {
+        var migrator = DatabaseMigrator()
+        
+        migrator.registerMigration("createPlayer") { db in
+            // Create a table
+            // See https://github.com/groue/GRDB.swift#create-tables
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                
+                // Sort player names in a localized case insensitive fashion by default
+                // See https://github.com/groue/GRDB.swift/blob/master/README.md#unicode
+                t.column("name", .text).notNull().collate(.localizedCaseInsensitiveCompare)
+                
+                t.column("score", .integer).notNull()
+            }
+        }
+        
+        migrator.registerMigration("fixtures") { db in
+            // Populate the players table with random data
+            for _ in 0..<8 {
+                var player = Player(id: nil, name: Player.randomName(), score: Player.randomScore())
+                try player.insert(db)
+            }
+        }
+        
+//        // Migrations for future application versions will be inserted here:
+//        migrator.registerMigration(...) { db in
+//            ...
+//        }
+        
+        return migrator
+    }
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/AppDelegate.swift
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/AppDelegate.swift
@@ -1,0 +1,37 @@
+//
+//  AppDelegate.swift
+//  GRDBDemo-SwiftUI
+//
+//  Created by Toby Brennan on 5/4/20.
+//  Copyright © 2020 Github-ApptekStudios. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+		// Override point for customization after application launch.
+		return true
+	}
+
+	// MARK: UISceneSession Lifecycle
+
+	func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+		// Called when a new scene session is being created.
+		// Use this method to select a configuration to create the new scene with.
+		return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+	}
+
+	func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+		// Called when the user discards a scene session.
+		// If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+		// Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+	}
+
+
+}
+

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/ContentView.swift
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/ContentView.swift
@@ -1,0 +1,123 @@
+//
+//  ContentView.swift
+//  GRDBDemo-SwiftUI
+//
+//  Created by Toby Brennan on 5/4/20.
+//  Copyright © 2020 Github-ApptekStudios. All rights reserved.
+//
+
+import SwiftUI
+import GRDB
+import GRDBCombine
+
+struct ContentViewModel {
+	/// A Hall of Fame
+	struct HallOfFame {
+		/// Total number of players
+		var playerCount: Int = 0
+		
+		/// The best ones
+		var bestPlayers: [Player] = []
+	}
+	
+	/// A publisher that tracks changes in the Hall of Fame
+	static func hallOfFameRequest(database: AppDatabase, maxPlayerCount: Int) -> DatabaseRequest<HallOfFame> {
+		DatabaseRequest(db: database.db, defaultValue: HallOfFame()) { db -> HallOfFame in
+			let playerCount = try Player.fetchCount(db)
+			let bestPlayers = try Player
+				.limit(maxPlayerCount)
+				.orderedByScore()
+				.fetchAll(db)
+			return HallOfFame(playerCount: playerCount, bestPlayers: bestPlayers)
+		}
+	}
+}
+
+struct ContentView: View {
+	@ObservedObject var databaseRequest = ContentViewModel.hallOfFameRequest(database: AppDatabase.shared, maxPlayerCount: 100)
+
+	var body: some View {
+		NavigationView {
+			VStack(spacing: 0) {
+				list
+				count
+				toolbar
+			}
+			.navigationBarItems(trailing: EditButton())
+			.navigationBarTitle(Text("Leaderboard"))
+		}
+	}
+	
+	var count: some View {
+		Text("\(databaseRequest.result.playerCount) \(databaseRequest.result.playerCount == 1 ? "Player" : "Players") in total")
+			.padding()
+			.frame(maxWidth: .infinity)
+			.background(Color(.secondarySystemBackground))
+	}
+	
+	var list: some View {
+		List {
+			ForEach(databaseRequest.result.bestPlayers) {
+				PlayerRow(player: $0)
+			}
+			.onDelete { indexSet in
+				let toDelete = indexSet.map { self.databaseRequest.result.bestPlayers[$0] }
+				
+				do {
+					//You should probably handle this in your data controller rather than in the view code
+					try AppDatabase.shared.db.write { db in
+						toDelete.forEach { player in
+							do {
+								try player.delete(db)
+							}
+							catch {
+								//Catch errors here so that the forEach completes as expected
+							}
+						}
+					}
+				}
+				catch {
+					// Handle any errors if considered important
+				}
+			}
+		}
+	}
+	
+	var toolbar: some View {
+		HStack {
+			Button(
+				action: { try? Players(database: AppDatabase.shared).deleteAll() },
+				label: { Image(systemName: "trash")})
+			Spacer()
+			Button(
+				action: { try? Players(database: AppDatabase.shared).refresh() },
+				label: { Image(systemName: "arrow.clockwise")})
+			Spacer()
+			Button(
+				action: { Players(database: AppDatabase.shared).stressTest() },
+				label: { Text("💣") })
+		}
+		.padding()
+	}
+}
+
+struct PlayerRow: View {
+	var player: Player
+	
+	var body: some View {
+		NavigationLink(destination: PlayerEditingView(player: DatabaseEditable(database: AppDatabase.shared.db, value: player, autoSave: false))) {
+			HStack {
+				Text(player.name)
+				Spacer()
+				Text("\(player.score)")
+			}
+		}
+	}
+}
+
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Info.plist
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Models/Player.swift
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Models/Player.swift
@@ -1,0 +1,69 @@
+import GRDB
+
+// A plain Player struct
+struct Player {
+    // Use Int64 for auto-incremented database ids
+    var id: Int64?
+    var name: String
+    var score: Int
+}
+
+// Support for UIViewController (difference(from:).inferringMoves())
+extension Player: Hashable { }
+
+// Support for SwiftUI (List)
+extension Player: Identifiable { }
+
+// MARK: - Persistence
+
+// Turn Player into a Codable Record.
+// See https://github.com/groue/GRDB.swift/blob/master/README.md#records
+extension Player: Codable, FetchableRecord, MutablePersistableRecord {
+    // Define database columns from CodingKeys
+    fileprivate enum Columns {
+        static let id = Column(CodingKeys.id)
+        static let name = Column(CodingKeys.name)
+        static let score = Column(CodingKeys.score)
+    }
+    
+    // Update a player id after it has been inserted in the database.
+    mutating func didInsert(with rowID: Int64, for column: String?) {
+        id = rowID
+    }
+}
+
+// MARK: - Database access
+
+// Define some useful player requests.
+// See https://github.com/groue/GRDB.swift/blob/master/README.md#requests
+extension DerivableRequest where RowDecoder == Player {
+    func orderedByName() -> Self {
+        order(Player.Columns.name)
+    }
+    
+    func orderedByScore() -> Self {
+        order(Player.Columns.score.desc, Player.Columns.name)
+    }
+}
+
+// MARK: - Player Randomization
+
+extension Player {
+    private static let names = [
+        "Arthur", "Anita", "Barbara", "Bernard", "Clément", "Chiara", "David",
+        "Dean", "Éric", "Elena", "Fatima", "Frederik", "Gilbert", "Georgette",
+        "Henriette", "Hassan", "Ignacio", "Irene", "Julie", "Jack", "Karl",
+        "Kristel", "Louis", "Liz", "Masashi", "Mary", "Noam", "Nolwenn",
+        "Ophelie", "Oleg", "Pascal", "Patricia", "Quentin", "Quinn", "Raoul",
+        "Rachel", "Stephan", "Susie", "Tristan", "Tatiana", "Ursule", "Urbain",
+        "Victor", "Violette", "Wilfried", "Wilhelmina", "Yvon", "Yann",
+        "Zazie", "Zoé"]
+    
+    static func randomName() -> String {
+        names.randomElement()!
+    }
+    
+    static func randomScore() -> Int {
+        10 * Int.random(in: 0...100)
+    }
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Models/Players.swift
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Models/Players.swift
@@ -1,0 +1,56 @@
+import Combine
+import GRDB
+import GRDBCombine
+import Dispatch
+
+/// Players is responsible for high-level operations on the players database.
+struct Players {
+    private let database: AppDatabase
+    
+    init(database: AppDatabase) {
+        self.database = database
+    }
+    
+    // MARK: - Modify Players
+    
+    func deleteAll() throws {
+		try database.db.write { db in
+            _ = try Player.deleteAll(db)
+        }
+    }
+    
+    func refresh() throws {
+		try database.db.write { db in
+            if try Player.fetchCount(db) == 0 {
+                // Insert new random players
+                for _ in 0..<8 {
+                    var player = Player(id: nil, name: Player.randomName(), score: Player.randomScore())
+                    try player.insert(db)
+                }
+            } else {
+                // Insert a player
+                if Bool.random() {
+                    var player = Player(id: nil, name: Player.randomName(), score: Player.randomScore())
+                    try player.insert(db)
+                }
+                // Delete a random player
+                if Bool.random() {
+                    try Player.order(sql: "RANDOM()").limit(1).deleteAll(db)
+                }
+                // Update some players
+                for var player in try Player.fetchAll(db) where Bool.random() {
+                    player.score = Player.randomScore()
+                    try player.update(db)
+                }
+            }
+        }
+    }
+    
+    func stressTest() {
+        for _ in 0..<50 {
+            DispatchQueue.global().async {
+                try? self.refresh()
+            }
+        }
+    }
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/PlayerEditingView.swift
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/PlayerEditingView.swift
@@ -1,0 +1,68 @@
+//
+//  PlayerEditingView.swift
+//  GRDBDemo-SwiftUI
+//
+//  Created by Toby Brennan on 5/4/20.
+//  Copyright © 2020 Github-ApptekStudios. All rights reserved.
+//
+
+import SwiftUI
+import GRDBCombine
+
+struct PlayerEditingView: View {
+	@ObservedObject
+	var player: DatabaseEditable<Player>
+	
+	@Environment(\.presentationMode) var presentation
+	
+	var scoreAsString: Binding<String> {
+		Binding(get: {
+			return "\(self.player.score)"
+		}) { (newValue) in
+			if let int = Int(newValue) {
+				self.player.score = int
+			}
+		}
+	}
+	
+    var body: some View {
+		NavigationView {
+			Form {
+				HStack {
+					Text("Player name").layoutPriority(1)
+					Spacer()
+					TextField("Player name", text: $player.name)
+						.multilineTextAlignment(.trailing)
+				}
+				HStack {
+					Text("Player score").layoutPriority(1)
+					Spacer()
+					TextField("Player score", text: scoreAsString)
+						.multilineTextAlignment(.trailing)
+				}
+				Button(action: {
+					do {
+						try self.player.commitChanges()
+						self.presentation.wrappedValue.dismiss()
+					}
+					catch {
+						// Do something if unable to save (eg. notify user)
+					}
+					
+				}) {
+					Text("Apply Changes")
+				}
+			}
+			.textFieldStyle(RoundedBorderTextFieldStyle())
+			.navigationBarTitle("Edit player")
+		}
+    }
+}
+
+struct PlayerEditingView_Previews: PreviewProvider {
+    static var previews: some View {
+		PlayerEditingView(player: .init(database: AppDatabase.shared.db, value: Player(name: "Test player", score: 99)))
+    }
+}
+
+import GRDB

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Resources/Assets.xcassets/Contents.json
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/Resources/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/SceneDelegate.swift
+++ b/Documentation/Demo-SwiftUI/GRDBDemo-SwiftUI/SceneDelegate.swift
@@ -1,0 +1,64 @@
+//
+//  SceneDelegate.swift
+//  GRDBDemo-SwiftUI
+//
+//  Created by Toby Brennan on 5/4/20.
+//  Copyright © 2020 Github-ApptekStudios. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+	var window: UIWindow?
+
+
+	func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+		// Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+		// If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+		// This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+
+		// Create the SwiftUI view that provides the window contents.
+		let contentView = ContentView()
+
+		// Use a UIHostingController as window root view controller.
+		if let windowScene = scene as? UIWindowScene {
+		    let window = UIWindow(windowScene: windowScene)
+		    window.rootViewController = UIHostingController(rootView: contentView)
+		    self.window = window
+		    window.makeKeyAndVisible()
+		}
+	}
+
+	func sceneDidDisconnect(_ scene: UIScene) {
+		// Called as the scene is being released by the system.
+		// This occurs shortly after the scene enters the background, or when its session is discarded.
+		// Release any resources associated with this scene that can be re-created the next time the scene connects.
+		// The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+	}
+
+	func sceneDidBecomeActive(_ scene: UIScene) {
+		// Called when the scene has moved from an inactive state to an active state.
+		// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+	}
+
+	func sceneWillResignActive(_ scene: UIScene) {
+		// Called when the scene will move from an active state to an inactive state.
+		// This may occur due to temporary interruptions (ex. an incoming phone call).
+	}
+
+	func sceneWillEnterForeground(_ scene: UIScene) {
+		// Called as the scene transitions from the background to the foreground.
+		// Use this method to undo the changes made on entering the background.
+	}
+
+	func sceneDidEnterBackground(_ scene: UIScene) {
+		// Called as the scene transitions from the foreground to the background.
+		// Use this method to save data, release shared resources, and store enough scene-specific state information
+		// to restore the scene back to its current state.
+	}
+
+
+}
+

--- a/Sources/GRDBCombine/DatabaseEditable.swift
+++ b/Sources/GRDBCombine/DatabaseEditable.swift
@@ -7,6 +7,9 @@ public class DatabaseEditable<Value: MutablePersistableRecord>: ObservableObject
 	let database: DatabaseWriter?
 	var autoSave: Bool
 	public var value: Value {
+		willSet {
+			objectWillChange.send()
+		}
 		didSet {
 			if autoSave {
 				try? commitChanges()

--- a/Sources/GRDBCombine/DatabaseEditable.swift
+++ b/Sources/GRDBCombine/DatabaseEditable.swift
@@ -6,7 +6,7 @@ import Combine
 public class DatabaseEditable<Value: MutablePersistableRecord>: ObservableObject {
 	let database: DatabaseWriter?
 	var autoSave: Bool
-	var value: Value {
+	public var value: Value {
 		didSet {
 			if autoSave {
 				try? commitChanges()

--- a/Sources/GRDBCombine/DatabaseEditable.swift
+++ b/Sources/GRDBCombine/DatabaseEditable.swift
@@ -1,0 +1,34 @@
+import GRDB
+import Combine
+
+@dynamicMemberLookup
+public class DatabaseEditable<Value: MutablePersistableRecord>: ObservableObject {
+	let database: DatabaseWriter
+	var autoSave: Bool
+	var value: Value {
+		didSet {
+			if autoSave {
+				try? commitChanges()
+			}
+		}
+	}
+	
+	public func commitChanges() throws {
+		try database.write {
+			try value.update($0)
+		}
+	}
+	
+	public init(database: DatabaseWriter, value: Value, autoSave: Bool = true) {
+		self.database = database
+		self.autoSave = autoSave
+		self.value = value
+	}
+	
+	public subscript<T>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> T
+	{
+		get { value[keyPath: keyPath] }
+		set { value[keyPath: keyPath] = newValue }
+	}
+}
+

--- a/Sources/GRDBCombine/DatabaseEditable.swift
+++ b/Sources/GRDBCombine/DatabaseEditable.swift
@@ -4,7 +4,7 @@ import Combine
 /// An observable object that holds a `MutablePersistableRecord` and allows mutation + updating the database row
 @dynamicMemberLookup
 public class DatabaseEditable<Value: MutablePersistableRecord>: ObservableObject {
-	let database: DatabaseWriter
+	let database: DatabaseWriter?
 	var autoSave: Bool
 	var value: Value {
 		didSet {
@@ -16,17 +16,16 @@ public class DatabaseEditable<Value: MutablePersistableRecord>: ObservableObject
 	
 	/// Call this function to manually save any changes to the record to the database
 	public func commitChanges() throws {
-		try database.write {
+		try database?.write {
 			try value.update($0)
 		}
 	}
 	
-	
 	/// Call this function to manually save any changes to the record to the database
-	/// - parameter database: The database to save any changes to
+	/// - parameter database: The database to save any changes to. If this is nil, changes to the value will not be saved.
 	/// - parameter value: The initial value
 	/// - parameter autoSave: Whether to automatically commit any changes to the database. Default = true
-	public init(database: DatabaseWriter, value: Value, autoSave: Bool = true) {
+	public init(database: DatabaseWriter?, value: Value, autoSave: Bool = true) {
 		self.database = database
 		self.autoSave = autoSave
 		self.value = value

--- a/Sources/GRDBCombine/DatabaseEditable.swift
+++ b/Sources/GRDBCombine/DatabaseEditable.swift
@@ -1,6 +1,7 @@
 import GRDB
 import Combine
 
+/// An observable object that holds a `MutablePersistableRecord` and allows mutation + updating the database row
 @dynamicMemberLookup
 public class DatabaseEditable<Value: MutablePersistableRecord>: ObservableObject {
 	let database: DatabaseWriter
@@ -13,18 +14,25 @@ public class DatabaseEditable<Value: MutablePersistableRecord>: ObservableObject
 		}
 	}
 	
+	/// Call this function to manually save any changes to the record to the database
 	public func commitChanges() throws {
 		try database.write {
 			try value.update($0)
 		}
 	}
 	
+	
+	/// Call this function to manually save any changes to the record to the database
+	/// - parameter database: The database to save any changes to
+	/// - parameter value: The initial value
+	/// - parameter autoSave: Whether to automatically commit any changes to the database. Default = true
 	public init(database: DatabaseWriter, value: Value, autoSave: Bool = true) {
 		self.database = database
 		self.autoSave = autoSave
 		self.value = value
 	}
 	
+	/// Allows for directly accessing/editing variables in the stored value
 	public subscript<T>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> T
 	{
 		get { value[keyPath: keyPath] }

--- a/Sources/GRDBCombine/DatabaseRequest.swift
+++ b/Sources/GRDBCombine/DatabaseRequest.swift
@@ -5,7 +5,11 @@ import GRDB
 /// An observable object that observes a database request and updates its `result` value with any changes
 public class DatabaseRequest<Data>: ObservableObject {
 	/// The result of the request. This is updated automatically with any changes.
-	@Published public var result: Data
+	public var result: Data {
+		willSet {
+			objectWillChange.send()
+		}
+	}
 	
 	private var subscription: AnyCancellable?
 	private let publisher: AnyPublisher<Data, Never>
@@ -59,8 +63,8 @@ public class DatabaseRequest<Data>: ObservableObject {
 	}
 	
 	private func subscribe() {
-		subscription = publisher.sink { [unowned self] result in
-			self.result = result
+		subscription = publisher.sink { [weak self] result in
+			self?.result = result
 		}
 	}
 }

--- a/Sources/GRDBCombine/DatabaseRequest.swift
+++ b/Sources/GRDBCombine/DatabaseRequest.swift
@@ -2,13 +2,15 @@ import Foundation
 import Combine
 import GRDB
 
+/// An observable object that observes a database request and updates its `result` value with any changes
 public class DatabaseRequest<Data>: ObservableObject {
+	/// The result of the request. This is updated automatically with any changes.
 	@Published public var result: Data
 	
 	private var subscription: AnyCancellable?
 	private let publisher: AnyPublisher<Data, Never>
 	
-	// Database request returning an array of records using a simple QueryInterfaceRequest
+	/// Database request returning an array of records using a simple QueryInterfaceRequest
 	public init<Database: DatabaseReader, DataElement: FetchableRecord>(db: Database, fetchRequest: QueryInterfaceRequest<DataElement>) where Data == [DataElement] {
 		self.result = []
 		self.publisher = ValueObservation
@@ -23,7 +25,7 @@ public class DatabaseRequest<Data>: ObservableObject {
 	
 	public typealias RequestClosure = ( (_ database: Database) throws -> Data)
 	
-	// Database request returning an array of Records
+	/// Database request returning an array of Records
 	public init<Database: DatabaseReader, DataElement>(db: Database, request: @escaping RequestClosure) where Data == [DataElement] {
 		self.result = []
 		self.publisher = ValueObservation
@@ -34,7 +36,7 @@ public class DatabaseRequest<Data>: ObservableObject {
 		subscribe()
 	}
 	
-	// Database request returning an non-optional result, with a default value if no record/s found
+	/// Database request returning an non-optional result, with a default value if no record/s found
 	public init<Database: DatabaseReader>(db: Database, defaultValue: Data, request: @escaping RequestClosure) {
 		self.result = defaultValue
 		self.publisher = ValueObservation
@@ -45,7 +47,7 @@ public class DatabaseRequest<Data>: ObservableObject {
 		subscribe()
 	}
 	
-	// Database request returning an optional Record
+	/// Database request returning an optional Record
 	public init<Database: DatabaseReader, DataElement>(db: Database, request: @escaping RequestClosure) where Data == Optional<DataElement> {
 		self.result = nil
 		self.publisher = ValueObservation
@@ -56,7 +58,7 @@ public class DatabaseRequest<Data>: ObservableObject {
 		subscribe()
 	}
 	
-	func subscribe() {
+	private func subscribe() {
 		subscription = publisher.sink { [unowned self] result in
 			self.result = result
 		}

--- a/Sources/GRDBCombine/DatabaseRequest.swift
+++ b/Sources/GRDBCombine/DatabaseRequest.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Combine
+import GRDB
+
+public class DatabaseRequest<Data>: ObservableObject {
+	@Published public var result: Data
+	
+	private var subscription: AnyCancellable?
+	private let publisher: AnyPublisher<Data, Never>
+	
+	// Database request returning an array of records using a simple QueryInterfaceRequest
+	public init<Database: DatabaseReader, DataElement: FetchableRecord>(db: Database, fetchRequest: QueryInterfaceRequest<DataElement>) where Data == [DataElement] {
+		self.result = []
+		self.publisher = ValueObservation
+			.tracking(value: { db in
+				try DataElement.fetchAll(db, fetchRequest)
+			})
+			.publisher(in: db)
+			.replaceError(with: [])
+			.eraseToAnyPublisher()
+		subscribe()
+	}
+	
+	public typealias RequestClosure = ( (_ database: Database) throws -> Data)
+	
+	// Database request returning an array of Records
+	public init<Database: DatabaseReader, DataElement>(db: Database, request: @escaping RequestClosure) where Data == [DataElement] {
+		self.result = []
+		self.publisher = ValueObservation
+			.tracking(value: request)
+			.publisher(in: db)
+			.replaceError(with: [])
+			.eraseToAnyPublisher()
+		subscribe()
+	}
+	
+	// Database request returning an non-optional result, with a default value if no record/s found
+	public init<Database: DatabaseReader>(db: Database, defaultValue: Data, request: @escaping RequestClosure) {
+		self.result = defaultValue
+		self.publisher = ValueObservation
+			.tracking(value: request)
+			.publisher(in: db)
+			.replaceError(with: defaultValue)
+			.eraseToAnyPublisher()
+		subscribe()
+	}
+	
+	// Database request returning an optional Record
+	public init<Database: DatabaseReader, DataElement>(db: Database, request: @escaping RequestClosure) where Data == Optional<DataElement> {
+		self.result = nil
+		self.publisher = ValueObservation
+			.tracking(value: request)
+			.publisher(in: db)
+			.replaceError(with: nil)
+			.eraseToAnyPublisher()
+		subscribe()
+	}
+	
+	func subscribe() {
+		subscription = publisher.sink { [unowned self] result in
+			self.result = result
+		}
+	}
+}
+

--- a/Sources/GRDBCombine/DatabaseRequest.swift
+++ b/Sources/GRDBCombine/DatabaseRequest.swift
@@ -62,6 +62,18 @@ public class DatabaseRequest<Data>: ObservableObject {
 		subscribe()
 	}
 	
+	/// Fake database request returning placeholder data (useful for testing / working on UI)
+	public static func placeholder(data: Data) -> DatabaseRequest<Data> {
+		DatabaseRequest(placeholderData: data)
+	}
+	
+	private init(placeholderData: Data) {
+		self.result = placeholderData
+		self.publisher = Just(placeholderData)
+			.eraseToAnyPublisher()
+		subscribe()
+	}
+	
 	private func subscribe() {
 		subscription = publisher.sink { [weak self] result in
 			self?.result = result


### PR DESCRIPTION
I've been loving getting to know GRDB over the last few days and thought I would experiment with how to best integrate it into SwiftUI projects. This PR adds two types that both conform to `ObservableObject` and can be used directly in SwiftUI views.

`DatabaseRequest` allows one to define a fetchRequest and have the view automatically update when the result changes.

`DatabaseEditable` allows for SwiftUI views to store and mutate a value conforming to `MutablePersistableRecord`. It provides options for automatically updating the database row on mutation, as well as manually committing changes to the database by calling `commitChanges()`.

These are best explained by checking out the SwiftUI demo project I have included in the PR 😄 